### PR TITLE
Fix: Transparent background for textarea and date picker

### DIFF
--- a/src/components/addJob/JobExtractionStep.tsx
+++ b/src/components/addJob/JobExtractionStep.tsx
@@ -27,7 +27,8 @@ export const JobExtractionStep: React.FC<JobExtractionStepProps> = ({
           value={jobDescription}
           onChange={(e) => setJobDescription(e.target.value)}
           placeholder="Paste the complete job description here..."
-          className="mt-2 min-h-[300px] bg-white/10 backdrop-blur-md border-white/20 text-white placeholder:text-white/50 resize-none focus-visible:ring-red-500 focus-visible:border-red-500"
+          className="mt-2 min-h-[300px] !bg-white/10 backdrop-blur-md border-white/20 text-white placeholder:text-white/50 resize-none focus-visible:ring-red-500 focus-visible:border-red-500"
+          style={{ backgroundColor: 'rgba(255, 255, 255, 0.1)' }}
           required
         />
         <p className="text-sm text-white/70 mt-2">
@@ -37,13 +38,14 @@ export const JobExtractionStep: React.FC<JobExtractionStepProps> = ({
 
       <div>
         <Label htmlFor="applicationDate" className="text-white font-medium">Application Date</Label>
-        <div className="relative w-full sm:w-fit mt-2">
+        <div className="relative w-full mt-2">
           <Input
             id="applicationDate"
             type="date"
             value={applicationDate}
             onChange={(e) => setApplicationDate(e.target.value)}
-            className="bg-white/10 backdrop-blur-md border-white/20 text-white pr-10 w-full sm:w-auto [&::-webkit-calendar-picker-indicator]:opacity-0 focus-visible:ring-red-500 focus-visible:border-red-500"
+            className="!bg-white/10 backdrop-blur-md border-white/20 text-white pr-10 w-full [&::-webkit-calendar-picker-indicator]:opacity-0 focus-visible:ring-red-500 focus-visible:border-red-500"
+            style={{ backgroundColor: 'rgba(255, 255, 255, 0.1)' }}
             required
           />
           <Calendar className="absolute right-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-white pointer-events-none" />


### PR DESCRIPTION
Ensured the textarea and date picker in job creation have transparent backgrounds to prevent white backgrounds in some cases.